### PR TITLE
If no filePath passed to module, use payload instead.

### DIFF
--- a/extract-keyframes.js
+++ b/extract-keyframes.js
@@ -10,6 +10,12 @@ module.exports = function(RED) {
 
         this.on('input', (msg) => {
 
+            debug('input', msg);
+
+            if(msg.payload.filePath === undefined){
+                msg.payload.filePath = msg.payload;
+            }
+
             extractKeyframes(msg.payload.filePath)
                 .then(extractionProcess => {
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-extract-keyframes",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-extract-keyframes",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Extract keyframes from a video file.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Most nodes (that I've used...) output images and videos as buffers on the payload property of the message object, and `node-red-contrib-extract-keyframes` doesn't handle this behaviour. 

This PR will check if a `filePath` property has been defined on the `payload` object and, if not, will set the value of `payload` to the value of `payload.filePath` (in order to keep compatibility between versions.)